### PR TITLE
Feature - Delete Saved Covers

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,3 +44,4 @@
     <script src="./src/main.js"></script>
   </body>
 </html>
+<id></id>

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ viewSavedButton.addEventListener("click", showSavedCovers);
 homeButton.addEventListener("click", showHome);
 createNewBookButton.addEventListener("click", createUserCover);
 saveCoverButton.addEventListener("click", saveCover);
-savedCoversSection.addEventListener("dblclick", removeSavedCover);
+savedCoversSection.addEventListener("dblclick", unsaveCover);
 
 // Create your event handlers and other functions here 👇
 
@@ -114,19 +114,22 @@ function saveCover() {
 
 function formatSavedCovers() {
   var miniCover =
-  `<div class="mini-covers mini-cover" data-id="${currentCover.id}"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
+  `<div class="entire-mini-cover mini-cover" data-id="${currentCover.id}"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
   savedCoversSection.insertAdjacentHTML('afterbegin', miniCover);
 }
 
-function removeSavedCover() {
-  var clickedMiniCover = event.target.closest(".mini-covers")
-  console.log(clickedMiniCover);
-  console.log(clickedMiniCover.dataset.id);
-  // for (var i = 0; i < savedCovers.length; i++) {
-  //   if (clickedMiniCover.dataset.id === savedCovers[i].id) {
-  //     console.log("Hello")
-  //   }
-  // }
+function unsaveCover() {
+  var clickedMiniCover = event.target.closest(".entire-mini-cover")
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (clickedMiniCover.dataset.id == `${savedCovers[i].id}`) {
+      savedCovers.splice(i, 1);
+      removeMiniCover(clickedMiniCover);
+    }
+  }
+}
+
+function removeMiniCover(cover) {
+  cover.remove();
 }
 
 //eventListener on double click invoking function

--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,9 @@ randomizeButton.addEventListener("click", createRandomCover);
 makeNewButton.addEventListener("click", showForm);
 viewSavedButton.addEventListener("click", showSavedCovers);
 homeButton.addEventListener("click", showHome);
-createNewBookButton.addEventListener("click", createUserCover)
-saveCoverButton.addEventListener("click", saveCover)
+createNewBookButton.addEventListener("click", createUserCover);
+saveCoverButton.addEventListener("click", saveCover);
+savedCoversSection.addEventListener("dblclick", removeCover);
 
 // Create your event handlers and other functions here 👇
 
@@ -113,9 +114,24 @@ function saveCover() {
 
 function formatSavedCovers() {
   var miniCover =
-  `<div class="mini-cover"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
+  `<div class="mini-cover"><id class="hidden">${currentCover.id}</id><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
   savedCoversSection.insertAdjacentHTML('afterbegin', miniCover);
 }
+
+function removeCover() {
+  var clickedMiniCover = event.target.closest(".mini-cover")
+  console.log(clickedMiniCover);
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (clickedMiniCover.id == savedCovers[i].id) {
+      console.log(hello);
+    }
+  }
+}
+
+//eventListener on double click invoking function
+// if
+//removes cover object from savedCovers array
+//removes what was clicked from view
 
 
 // We've provided one function to get you started

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ viewSavedButton.addEventListener("click", showSavedCovers);
 homeButton.addEventListener("click", showHome);
 createNewBookButton.addEventListener("click", createUserCover);
 saveCoverButton.addEventListener("click", saveCover);
-savedCoversSection.addEventListener("dblclick", removeCover);
+savedCoversSection.addEventListener("dblclick", removeSavedCover);
 
 // Create your event handlers and other functions here 👇
 
@@ -114,16 +114,17 @@ function saveCover() {
 
 function formatSavedCovers() {
   var miniCover =
-  `<div class="mini-cover"><id class="hidden">${currentCover.id}</id><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
+  `<div class="mini-cover" data-id="${currentCover.id}"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
   savedCoversSection.insertAdjacentHTML('afterbegin', miniCover);
 }
 
-function removeCover() {
+function removeSavedCover() {
   var clickedMiniCover = event.target.closest(".mini-cover")
   console.log(clickedMiniCover);
+  console.log(clickedMiniCover.dataset.id);
   for (var i = 0; i < savedCovers.length; i++) {
-    if (clickedMiniCover.id == savedCovers[i].id) {
-      console.log(hello);
+    if (clickedMiniCover.dataset.id === savedCovers[i].id) {
+      console.log("Hello")
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -114,19 +114,19 @@ function saveCover() {
 
 function formatSavedCovers() {
   var miniCover =
-  `<div class="mini-cover" data-id="${currentCover.id}"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
+  `<div class="mini-covers mini-cover" data-id="${currentCover.id}"><img class="mini-cover" src="${currentCover.cover}"><h2 class="cover-title first-letter">${currentCover.title}</h2><h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}</h3></div>`
   savedCoversSection.insertAdjacentHTML('afterbegin', miniCover);
 }
 
 function removeSavedCover() {
-  var clickedMiniCover = event.target.closest(".mini-cover")
+  var clickedMiniCover = event.target.closest(".mini-covers")
   console.log(clickedMiniCover);
   console.log(clickedMiniCover.dataset.id);
-  for (var i = 0; i < savedCovers.length; i++) {
-    if (clickedMiniCover.dataset.id === savedCovers[i].id) {
-      console.log("Hello")
-    }
-  }
+  // for (var i = 0; i < savedCovers.length; i++) {
+  //   if (clickedMiniCover.dataset.id === savedCovers[i].id) {
+  //     console.log("Hello")
+  //   }
+  // }
 }
 
 //eventListener on double click invoking function


### PR DESCRIPTION
# Pull Request Template

#### What’s this PR do? 
It allows us to remove saved covers from the saved covers section.
1. Refactors the insterted HTML that creates the mini covers so that they can be manipulated by the DOM/
2. It updates the saved covers array by removing an element when a user double clicks
3. The same cover that gets clicked also disappears

#### Where should the reviewer start?
In `main.js` see updates to `formatSavedCovers()` and new `unsaveCover()`, `removeMiniCover` functions

#### How should this be manually tested?
Save a few covers, go to the saved covers view, console.log the savedCovers array, double click a cover to see it removed and console.log the savedCovers array again to see that the length is one less.


#### Screenshots (if appropriate): 

![ezgif-4-16b74ee2c4d3](https://user-images.githubusercontent.com/59029768/91647326-dd3a7f80-ea16-11ea-8a6c-84f7bf48cb27.gif)

